### PR TITLE
make 10x support optional

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,3 @@ sphinx
 alabaster
 recommonmark
 sphinxcontrib-napoleon
-pathos
-bamnostic>=0.9.2

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ SETUP_METADATA = \
         'test' : ['pytest', 'pytest-cov', 'numpy', 'matplotlib', 'scipy','recommonmark'],
         'demo' : ['jupyter', 'jupyter_client', 'ipython'],
         'doc' : ['sphinx'],
+        '10x': ['pathos', 'bamnostic>=0.9.2'],
         },
     "include_package_data": True,
     "package_data": {

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -4,7 +4,6 @@ import argparse
 import csv
 import itertools
 import multiprocessing
-import pathos.multiprocessing as mp
 import os
 import os.path
 import sys
@@ -16,7 +15,6 @@ from . import signature as sig
 from . import sourmash_args
 from .logging import notify, error, print_results, set_quiet
 from .sbtmh import SearchMinHashesFindBest, SigLeaf
-from .tenx import read_10x_folder
 
 from .sourmash_args import DEFAULT_LOAD_K
 DEFAULT_COMPUTE_K = '21,31,51'
@@ -267,6 +265,9 @@ def compute(args):
                 notify('calculated {} signatures for {} sequences in {}',
                        len(siglist), n + 1, filename)
             elif args.input_is_10x:
+                import pathos.multiprocessing as mp
+                from .tenx import read_10x_folder
+
                 barcodes, bam_file = read_10x_folder(filename)
                 manager = multiprocessing.Manager()
 

--- a/sourmash/tenx.py
+++ b/sourmash/tenx.py
@@ -1,5 +1,4 @@
 import os
-import bamnostic as bs
 
 
 def read_single_column(filename):
@@ -11,6 +10,8 @@ def read_single_column(filename):
 
 def read_10x_folder(folder):
     """Get QC-pass barcodes, genes, and bam file from a 10x folder"""
+    import bamnostic as bs
+
     barcodes = read_single_column(os.path.join(folder, 'barcodes.tsv'))
 
     bam_file = bs.AlignmentFile(

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,8 @@ deps=
     codecov
     ipfsapi
     redis
-    pysam
+    bamnostic
+    pathos
 commands=
     pip install -r requirements.txt
     pip install -e .[test]


### PR DESCRIPTION
Hi @olgabot! I made the `10x` support optional (it is weird Python with all the `import` inside functions...), but it avoids pulling in `bamnostic` and `pathos` as deps.

for `pip` you can do `pip install --pre sourmash[10x]` to install it, and in bioconda we will probably bring `pathos` and `bamnostic` anyway.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
