### PR TITLE
Define 'n' before using it

### DIFF
--- a/sourmash/command_compute.py
+++ b/sourmash/command_compute.py
@@ -362,6 +362,7 @@ def compute(args):
         # make minhashes for the whole file
         Elist = make_minhashes()
 
+        n = 0
         total_seq = 0
         for filename in args.filenames:
             # consume & calculate signatures


### PR DESCRIPTION
Getting this error in here https://github.com/nf-core/kmermaid/pull/17, at least locally:

```

  == This is sourmash version 2.0.0a10.dev119+gf9bd45f. ==

  == Please cite Brown and Irber (2016), doi:10.21105/joss.00027. ==


  computing signatures for files: SRR4238355_subsamp_coding_reads_peptides.fasta

  Computing signature for ksizes: [6]

  Computing only Dayhoff-encoded protein (and not nucleotide) signatures.

  Computing a total of 1 signature(s).

  ... reading sequences from SRR4238355_subsamp_coding_reads_peptides.fasta
  Traceback (most recent call last):
    File "/opt/conda/envs/nfcore-kmermaid-0.1dev/bin/sourmash", line 8, in <module>
      sys.exit(main())
    File "/opt/conda/envs/nfcore-kmermaid-0.1dev/lib/python3.6/site-packages/sourmash/__main__.py", line 83, in main
      cmd(sys.argv[2:])
    File "/opt/conda/envs/nfcore-kmermaid-0.1dev/lib/python3.6/site-packages/sourmash/command_compute.py", line 376, in compute
      notify('... {} {} sequences', filename, n + 1)
  UnboundLocalError: local variable 'n' referenced before assignment
```

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
